### PR TITLE
Add ECDSA support. This fixes #1

### DIFF
--- a/sshfp
+++ b/sshfp
@@ -22,13 +22,12 @@ except ImportError:
 	print >> sys.stderr, "openSUSE: zypper in python-dnspython"
 	sys.exit(1)
 
+ishashlib = False
 try:
 	import hashlib
-	digest = hashlib.sha1
+	ishashlib = True
 except ImportError:
 	import sha
-	digest = sha.new
-
 
 global all_hosts
 global khfile
@@ -38,6 +37,7 @@ global quiet
 global port
 global timeout
 global algo
+global fphashes
 
 VERSION = "1.2.2"
 DEFAULT_KNOWN_HOSTS_FILE = "~/.ssh/known_hosts"
@@ -48,7 +48,7 @@ def show_version():
 	print >> sys.stderr, "Author:\n Paul Wouters <paul@xelerance.com>"
 	print >> sys.stderr, " James Brown <jbrown@yelp.com>"
 
-def create_sshfp(hostname, keytype, keyblob):
+def create_sshfp(hostname, keytype, keyblob, fphash):
 	"""Creates an SSH fingerprint"""
 
 	if keytype == "ssh-rsa":
@@ -64,7 +64,18 @@ def create_sshfp(hostname, keytype, keyblob):
 	except TypeError:
 		print >> sys.stderr, "FAILED on hostname "+hostname+" with keyblob "+keyblob
 		return "ERROR"
-	fpsha1 = digest(rawkey).hexdigest().upper()
+
+	hashcode = "1"
+	if ishashlib:
+		if fphash == "sha2":
+		  digest = hashlib.sha256
+		  hashcode = "2"
+		else:
+		  digest = hashlib.sha1
+	else:
+		digest = sha.new
+	fp = digest(rawkey).hexdigest().upper()
+
 	# check for Reverse entries
 	reverse = 1
 	parts = hostname.split(".", 3)
@@ -79,7 +90,7 @@ def create_sshfp(hostname, keytype, keyblob):
 	if trailing and not reverse:
 		if hostname[-1:] != ".":
 			hostname = hostname + "."
-	return hostname + " IN SSHFP " + keytype + " 1 " + fpsha1
+	return hostname + " IN SSHFP " + keytype + " " + hashcode + " " + fp
 
 def get_known_host_entry(known_hosts, host):
 	"""Get a single entry out of a known_hosts file
@@ -140,14 +151,21 @@ def check_keytype(keytype):
 	return False
 
 def process_record(record, hostname):
+	global fphashes
+	all_records = []
 	(host, keytype, key) = record.split(" ")
 	key = key.rstrip()
 	if check_keytype(keytype):
-		record = create_sshfp(hostname, keytype, key)
-		return record
-	return ""
+		for fphash in fphashes: 
+			  all_records.append(create_sshfp(host, keytype, key, fphash))
+	if all_records:
+		all_records.sort()
+		return "\n".join(all_records)
+	else:
+		return ""
 
 def process_records(data, hostnames):
+	global fphashes
 	"""Process all records in a string.
 
 	If the global "all_hosts" is True, then return SSHFP entries
@@ -156,6 +174,7 @@ def process_records(data, hostnames):
 	If "all_hosts is False and hostnames is non-empty, return
 	only the items in hostnames
 	"""
+	
 	all_records = []
 	for record in data.split("\n"):
 		if record.startswith("#") or not record:
@@ -171,7 +190,8 @@ def process_records(data, hostnames):
 		if all_hosts or host in hostnames or host == hostnames:
 			if not check_keytype(keytype):
 				continue
-			all_records.append(create_sshfp(host, keytype, key))
+			for fphash in fphashes: 
+			  all_records.append(create_sshfp(host, keytype, key, fphash))
 	if all_records:
 		all_records.sort()
 		return "\n".join(all_records)
@@ -253,6 +273,7 @@ def main():
 	global port
 	global timeout
 	global algos
+	global fphashes
 
 	parser = optparse.OptionParser()
 	parser.add_option("-k", "--knownhosts", "--known-hosts", 
@@ -311,6 +332,13 @@ def main():
 			dest="nameserver",
 			default="",
 			help="nameserver to use for AXFR (only valid with -s -a)")
+	parser.add_option("-H", "--hashfunction", 
+			action="append",
+			type="choice",
+			dest="fphashes",
+			choices=["sha1", "sha2"],
+			default=[],
+			help="Hash function to use, default sha1,sha2")
 	(options, args) = parser.parse_args()
 
 	# parse options
@@ -326,6 +354,7 @@ def main():
 	algos = options.algo or ["dsa", "rsa", "ecdsa"]
 	all_hosts = options.all_hosts
 	port = options.port
+	fphashes = options.fphashes or ["sha1", "sha2"]
 	hostnames = ()
 
 	if options.version:
@@ -343,6 +372,9 @@ def main():
 	if not args and (not all_hosts):
 		print >> sys.stderr, "WARNING: Assuming -a"
 		all_hosts = True
+	if not ishashlib and "sha2" in options.fphashes:
+		print >> sys.stderr, "WARNING: Hashlib not supported, ignoring -H sha2"
+		fphashes = ["sha1"]
 
 	if options.scan and options.all_hosts:
 		datal = []


### PR DESCRIPTION
I changed my mind, here's the patch.

I'm not sure about this part:
-  if not quiet:  
-    print >> sys.stderr, "Could only find key type %s for %s" % (keytype, hostname)
