### PR TITLE
Preparing for 1.3.0 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+v1.3.0 (Jun, 2016)
+- dane: Allow following CNAME. This is useful for servers with SNI enabled. [Arne Schwabe]
+- sshfp: Added support for ecdsa keys. [Danny Fullerton]
+- sshfp: Add fingerprint type 2 support (sha-256). [Danny Fullerton]
+- sshfp: Added support for ed25519 keys. [Nirgal Vourgère]
+- sshfp: Add support for IPv6 AAAA records. [Jinn Koriech]
+- sshfp: Add support for regex filters and for probing multiple ports at once. [Jinn Koriech]
+
 v1.2.2 (Sep 6, 2011)
 - Fix -4 / -6 flags [Chris]
 - Throw errors on stderr to improve pipe usage [Ludwig Nusse]

--- a/dane
+++ b/dane
@@ -200,7 +200,7 @@ parser.add_argument('hosts', metavar="hostname", nargs='+')
 args = parser.parse_args(sys.argv[1:])
 
 if args.version:
-	sys.exit("dane: version 1.2.2")
+	sys.exit("dane: version 1.3.0")
 if not args.rfc:
 	args.draft = True
 


### PR DESCRIPTION
Hi

My pull request on sshfp, adding support for ed25519, was merged back in January 2015.
Since then, there was many fixes by Jinn Koriech, including the change of VERSION in sshfp (line 45).

Could you please consider releasing version 1.3.0 ?

That pull request prepares the code for that.

After you merge, it is a simple matter of tagging the code. Locally:

```
git pull
git tag -s 1.3.0
git push --tags
```

(Remove -s if you don't use gnupg)

Then https://github.com/xelerance/sshfp/releases will show version 1.3.0
